### PR TITLE
Fix “Fork me on GitHub” ribbon link

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     </style>
   </head>
   <body>
-    <a href="https://github.com/gozala/wisp"><img style="z-index: 3; position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
+    <a href="https://github.com/Gozala/try-wisp"><img style="z-index: 3; position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
     <script type=text/expamles id=examples>;; # wisp
 
 ; Wisp is homoiconic JS dialect with a clojure syntax, s-expressions and


### PR DESCRIPTION
If I click that ribbon, I expect to view the project of the live editor, not the Wisp language. Those interested in the language can follow the link from the editor’s README.
