### PR TITLE
Make the CodeMirror editor auto-close brackets

### DIFF
--- a/src/main.wisp
+++ b/src/main.wisp
@@ -59,6 +59,7 @@
   (CodeMirror (.get-element-by-id document :input)
               {:lineNumbers true
                :matchBrackets true
+               :autoCloseBrackets "()[]{}\"\""
                :electricChars true
                :persist true
 


### PR DESCRIPTION
This will make balancing parentheses easier, which is especially important when editing Lisp.

The brackets string I pass is the default string with `''` removed, since a single `'` is used to quote an expression.
